### PR TITLE
5 set up ci pipeline for backend project

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,4 +39,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: backend-app
-          path: ./publish
+          path: backend/publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         run: dotnet test --verbosity normal
 
       - name: Publish
-        run: dotnet publish -c Release -o ./publish
+        run: dotnet publish ./src/Semzeri.API/Semzeri.API.csproj -c Release -o ./publish
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Run tests
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --verbosity normal
 
       - name: Publish
         run: dotnet publish -c Release -o ./publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 5-set-up-ci-pipeline-for-backend-project
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: backend
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Resolved artifact upload issue by specifying the correct relative path (backend/publish) instead of ./publish.